### PR TITLE
znc bugfix & bracket

### DIFF
--- a/src/IRC/Types.hs
+++ b/src/IRC/Types.hs
@@ -8,12 +8,14 @@ module IRC.Types
   , Pack
   , Connection
   , Hook(..)
+  , Options(..)
 ) where
 
 import           Control.Error        (ExceptT)
 import           Data.CaseInsensitive (CI)
 import           Network.SimpleIRC    (IrcEvent, MIrc)
 import           Network.Socket       (PortNumber)
+import           Data.IP              (IPv4)
 
 
 type Network = String
@@ -37,3 +39,19 @@ data IrcParams = IrcParams { host     :: Network
 data Hook = Hook { onConnect    :: Connection -> IO ()
                  , onEvent      :: [IrcEvent]
                  , onDisconnect :: Connection -> IO () }
+
+data Options = Options { network            :: Network
+                       , mainChannel        :: Channel
+                       , rNick              :: Nickname
+                       , packno             :: Pack
+                       , rPort              :: PortNumber
+                       , usesecure          :: Bool
+                       , user               :: Nickname
+                       , pass               :: Maybe Password
+                       , nick               :: Nickname
+                       , additionalChannels :: [Channel]
+                       , publicIp           :: Maybe IPv4
+                       , lPort              :: Maybe PortNumber
+                       , zncAutoConnect     :: Bool
+                       , verbose            :: Bool }
+    deriving (Show)

--- a/xdcc.cabal
+++ b/xdcc.cabal
@@ -45,5 +45,6 @@ executable xdcc
                       , simpleirc >= 0.3.1 && < 0.4
                       , transformers >= 0.4.2.0 && < 0.5
                       , unix-compat >= 0.4.1.0 && < 0.4.2
+                      , lifted-base >=0.2.3.0 && < 0.3                     
   default-language:     Haskell2010
   ghc-options:          -Wall


### PR DESCRIPTION
Hallo @JanGe 

wir können offenbar deutsch miteinander sprechen.

Ich habe zwei bugs gefixed.
1. Dein 'bracket' hat keine exceptions gefangen, ich habe es deshalb durch die Version aus dem lifted-base package ersetzt. 
2. znc schließt den Socket sobald es die '*status' Message 'disconnect' bekommt. Deshalb darf nach dem disconnect-Hook keine 'QUIT' Message mehr geschickt werden wenn znc benutzt wird, sonst gibt es eine exception.

MfG,
cbm80
